### PR TITLE
Add an alternative formatter with more fraction digits

### DIFF
--- a/lib/CryptoAPI.js
+++ b/lib/CryptoAPI.js
@@ -14,6 +14,12 @@ class CryptoAPI {
         style: 'currency',
         currency: curOption
       });
+      // Formatter for currency prices too low
+      const formatterTinyPrice = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: curOption,
+        maximumFractionDigits: 8
+      });
 
       const res = await axios.get(
         `${this.baseUrl}?key=${this.apiKey}&ids=${coinOption}&convert=${curOption}`
@@ -23,7 +29,7 @@ class CryptoAPI {
 
       res.data.forEach(coin => {
         output += `Coin: ${coin.symbol.yellow} (${coin.name}) | Price: ${
-          formatter.format(coin.price).green
+          coin.price > 0.1 ? formatter.format(coin.price).green : formatterTinyPrice.format(coin.price).green
         } | Rank: ${coin.rank.blue}\n`;
       });
 


### PR DESCRIPTION
For cryptocurrencies with price too low, like, for example, VET (Vechain Thor), currently the console output shows $0.00. 

In my opinion adding another formatter with more fraction digits and applying it depending if coin.price is lower than 0.1 resolves the issue.